### PR TITLE
Fix cold-start-strategy

### DIFF
--- a/src/MovieModel.ipynb
+++ b/src/MovieModel.ipynb
@@ -30,8 +30,8 @@
    "execution_count": 1,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2020-01-16T10:05:20.683203Z",
-     "start_time": "2020-01-16T10:05:20.255946Z"
+     "end_time": "2020-01-16T20:31:29.501459Z",
+     "start_time": "2020-01-16T20:31:28.553440Z"
     }
    },
    "outputs": [],
@@ -54,8 +54,8 @@
    "execution_count": 2,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2020-01-16T10:05:26.135834Z",
-     "start_time": "2020-01-16T10:05:26.129618Z"
+     "end_time": "2020-01-16T20:31:29.512300Z",
+     "start_time": "2020-01-16T20:31:29.506384Z"
     }
    },
    "outputs": [],
@@ -80,8 +80,8 @@
    "execution_count": 3,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2020-01-16T10:05:35.706542Z",
-     "start_time": "2020-01-16T10:05:29.831272Z"
+     "end_time": "2020-01-16T20:31:40.259182Z",
+     "start_time": "2020-01-16T20:31:29.634109Z"
     }
    },
    "outputs": [],
@@ -106,11 +106,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 4,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2020-01-16T10:16:06.466683Z",
-     "start_time": "2020-01-16T10:15:46.353562Z"
+     "end_time": "2020-01-16T20:31:49.393037Z",
+     "start_time": "2020-01-16T20:31:40.262518Z"
     }
    },
    "outputs": [
@@ -145,52 +145,52 @@
        "    <tr>\n",
        "      <th>0</th>\n",
        "      <td>1</td>\n",
-       "      <td>307</td>\n",
-       "      <td>3.5</td>\n",
-       "      <td>1256677221</td>\n",
+       "      <td>1</td>\n",
+       "      <td>4.0</td>\n",
+       "      <td>964982703</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
        "      <td>1</td>\n",
-       "      <td>481</td>\n",
-       "      <td>3.5</td>\n",
-       "      <td>1256677456</td>\n",
+       "      <td>3</td>\n",
+       "      <td>4.0</td>\n",
+       "      <td>964981247</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
        "      <td>1</td>\n",
-       "      <td>1091</td>\n",
-       "      <td>1.5</td>\n",
-       "      <td>1256677471</td>\n",
+       "      <td>6</td>\n",
+       "      <td>4.0</td>\n",
+       "      <td>964982224</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>3</th>\n",
        "      <td>1</td>\n",
-       "      <td>1257</td>\n",
-       "      <td>4.5</td>\n",
-       "      <td>1256677460</td>\n",
+       "      <td>47</td>\n",
+       "      <td>5.0</td>\n",
+       "      <td>964983815</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>4</th>\n",
        "      <td>1</td>\n",
-       "      <td>1449</td>\n",
-       "      <td>4.5</td>\n",
-       "      <td>1256677264</td>\n",
+       "      <td>50</td>\n",
+       "      <td>5.0</td>\n",
+       "      <td>964982931</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
        "</div>"
       ],
       "text/plain": [
-       "   userId  movieId  rating   timestamp\n",
-       "0       1      307     3.5  1256677221\n",
-       "1       1      481     3.5  1256677456\n",
-       "2       1     1091     1.5  1256677471\n",
-       "3       1     1257     4.5  1256677460\n",
-       "4       1     1449     4.5  1256677264"
+       "   userId  movieId  rating  timestamp\n",
+       "0       1        1     4.0  964982703\n",
+       "1       1        3     4.0  964981247\n",
+       "2       1        6     4.0  964982224\n",
+       "3       1       47     5.0  964983815\n",
+       "4       1       50     5.0  964982931"
       ]
      },
-     "execution_count": 11,
+     "execution_count": 4,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -199,7 +199,7 @@
     "raw_data = spark.read.format(\"csv\") \\\n",
     "  .option(\"header\", \"true\") \\\n",
     "  .option(\"inferSchema\", \"true\") \\\n",
-    "  .load(complete_ratings_file)\n",
+    "  .load(small_ratings_file)\n",
     "raw_data.limit(5).toPandas()"
    ]
   },
@@ -212,11 +212,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 5,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2020-01-16T10:18:16.060991Z",
-     "start_time": "2020-01-16T10:17:46.611127Z"
+     "end_time": "2020-01-16T20:31:51.940945Z",
+     "start_time": "2020-01-16T20:31:49.395820Z"
     }
    },
    "outputs": [
@@ -224,8 +224,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "train_df records: 20818046\n",
-      "test_df records: 6935398\n"
+      "train_df records: 75681\n",
+      "test_df records: 25155\n"
      ]
     }
    ],
@@ -252,11 +252,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 6,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2020-01-16T10:18:16.182334Z",
-     "start_time": "2020-01-16T10:18:16.063640Z"
+     "end_time": "2020-01-16T20:31:52.304210Z",
+     "start_time": "2020-01-16T20:31:51.944225Z"
     }
    },
    "outputs": [],
@@ -269,6 +269,8 @@
     "    \n",
     "# define the model type to train - in this case an Alternating Least Squares (ALS) mode to predict a continuous variable 'prediction'\n",
     "# https://spark.apache.org/docs/latest/api/python/pyspark.ml.html#module-pyspark.ml.recommendation\n",
+    "# see https://spark.apache.org/docs/latest/ml-collaborative-filtering.html for implementation details\n",
+    "# pay attention to cold-start-strategy which details strategy for how to deal with customers which do not have enough responses to determine their similarity to other customers\n",
     "als = ALS(\n",
     "  rank=10, \n",
     "  maxIter=10, \n",
@@ -285,7 +287,7 @@
     "  checkpointInterval=10, \n",
     "  intermediateStorageLevel='MEMORY_AND_DISK', \n",
     "  finalStorageLevel='MEMORY_AND_DISK', \n",
-    "  coldStartStrategy='nan')    \n",
+    "  coldStartStrategy='drop')    \n",
     "\n",
     "# define a sequence of stages\n",
     "# in this case we have only one stage but normally some feature engineering would happen before the model (https://spark.apache.org/docs/latest/api/python/pyspark.ml.html#module-pyspark.ml.feature)\n",
@@ -316,11 +318,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 7,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2020-01-16T10:23:35.440653Z",
-     "start_time": "2020-01-16T10:18:16.185219Z"
+     "end_time": "2020-01-16T20:33:21.805840Z",
+     "start_time": "2020-01-16T20:31:52.306810Z"
     }
    },
    "outputs": [],
@@ -331,11 +333,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 8,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2020-01-16T10:26:20.204932Z",
-     "start_time": "2020-01-16T10:23:35.445918Z"
+     "end_time": "2020-01-16T20:34:41.318541Z",
+     "start_time": "2020-01-16T20:33:21.812109Z"
     }
    },
    "outputs": [
@@ -343,15 +345,15 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{\"fold\": 1, \"grid\": 1, \"rank\": 4, \"rmse\": 0.8053790403682802}\n",
-      "{\"fold\": 1, \"grid\": 2, \"rank\": 8, \"rmse\": 0.7793625457224646}\n",
-      "{\"fold\": 1, \"grid\": 3, \"rank\": 12, \"rmse\": 0.7694984401340923}\n",
-      "{\"fold\": 2, \"grid\": 1, \"rank\": 4, \"rmse\": 0.8034913068680214}\n",
-      "{\"fold\": 2, \"grid\": 2, \"rank\": 8, \"rmse\": 0.7768507292139907}\n",
-      "{\"fold\": 2, \"grid\": 3, \"rank\": 12, \"rmse\": 0.7696234796010009}\n",
-      "{\"fold\": 3, \"grid\": 1, \"rank\": 4, \"rmse\": 0.8019533588035967}\n",
-      "{\"fold\": 3, \"grid\": 2, \"rank\": 8, \"rmse\": 0.7760009226180817}\n",
-      "{\"fold\": 3, \"grid\": 3, \"rank\": 12, \"rmse\": 0.7685135658298837}\n"
+      "{\"fold\": 1, \"grid\": 1, \"rank\": 4, \"rmse\": 0.7262748350505489}\n",
+      "{\"fold\": 1, \"grid\": 2, \"rank\": 8, \"rmse\": 0.6774952928110416}\n",
+      "{\"fold\": 1, \"grid\": 3, \"rank\": 12, \"rmse\": 0.6548876426568273}\n",
+      "{\"fold\": 2, \"grid\": 1, \"rank\": 4, \"rmse\": 0.7269762973982319}\n",
+      "{\"fold\": 2, \"grid\": 2, \"rank\": 8, \"rmse\": 0.6821879249409497}\n",
+      "{\"fold\": 2, \"grid\": 3, \"rank\": 12, \"rmse\": 0.6596626134414807}\n",
+      "{\"fold\": 3, \"grid\": 1, \"rank\": 4, \"rmse\": 0.7296546594659135}\n",
+      "{\"fold\": 3, \"grid\": 2, \"rank\": 8, \"rmse\": 0.6859068076829552}\n",
+      "{\"fold\": 3, \"grid\": 3, \"rank\": 12, \"rmse\": 0.6585555992240535}\n"
      ]
     }
    ],
@@ -361,7 +363,7 @@
     "# you can see that this is a brute force parameter search. This means the more .addGrid() parameters and CrossValidator.numFolds tested will result in longer training time but potentially a better model\n",
     "for fold, foldModel in enumerate(crossValidatorModel.subModels, start=1):\n",
     "    for grid, gridModel in enumerate(foldModel, start=1):\n",
-    "        prediction = gridModel.transform(train_df).where(\"prediction != 'NaN'\")\n",
+    "        prediction = gridModel.transform(train_df)\n",
     "        rmse = regressionEvaluator.evaluate(prediction)\n",
     "        rank = gridModel.stages[-1].rank\n",
     "        print(f'{{\"fold\": {fold}, \"grid\": {grid}, \"rank\": {rank}, \"rmse\": {rmse}}}')"
@@ -372,8 +374,8 @@
    "execution_count": 9,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2020-01-16T10:12:48.960441Z",
-     "start_time": "2020-01-16T10:12:45.695806Z"
+     "end_time": "2020-01-16T20:34:47.414963Z",
+     "start_time": "2020-01-16T20:34:41.321379Z"
     }
    },
    "outputs": [
@@ -388,33 +390,10 @@
    "source": [
     "# test the best trained model against the reserved test set to verify no overfitting\n",
     "bestModel = crossValidatorModel.bestModel\n",
-    "prediction = bestModel.transform(test_df).where(\"prediction != 'NaN'\")\n",
+    "prediction = bestModel.transform(test_df)\n",
     "rmse = regressionEvaluator.evaluate(prediction)\n",
     "rank = bestModel.stages[-1].rank\n",
     "print(f'{{\"rank\": {rank}, \"rmse\": {rmse}}}')"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "If you are happy with the rmse listed above export the model ready for use"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 10,
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2020-01-16T10:13:03.869816Z",
-     "start_time": "2020-01-16T10:13:01.476925Z"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "bestModel.write() \\\n",
-    "  .overwrite() \\\n",
-    "  .save(model_path)"
    ]
   },
   {
@@ -442,6 +421,46 @@
     "  .load(complete_ratings_file)\n",
     "raw_data.limit(5).toPandas()\n",
     "`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2020-01-16T20:34:47.452319Z",
+     "start_time": "2020-01-16T20:34:47.424242Z"
+    }
+   },
+   "outputs": [
+    {
+     "ename": "SyntaxError",
+     "evalue": "invalid syntax (<ipython-input-10-5d0b29b72933>, line 2)",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;36m  File \u001b[0;32m\"<ipython-input-10-5d0b29b72933>\"\u001b[0;36m, line \u001b[0;32m2\u001b[0m\n\u001b[0;31m    If you are happy with the rmse listed above export the model ready for use\u001b[0m\n\u001b[0m         ^\u001b[0m\n\u001b[0;31mSyntaxError\u001b[0m\u001b[0;31m:\u001b[0m invalid syntax\n"
+     ]
+    }
+   ],
+   "source": [
+    "## Export the model for production\n",
+    "If you are happy with the rmse listed above export the model ready for use"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2020-01-16T20:34:47.464347Z",
+     "start_time": "2020-01-16T20:32:16.692Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "bestModel.write() \\\n",
+    "  .overwrite() \\\n",
+    "  .save(model_path)"
    ]
   },
   {


### PR DESCRIPTION
collaborative filtering requires a certain level of 'reviews' for a new user before it can build a user 'profile' to base recommendations from. I think netflix used to ask people to list their favourite movies when they joined to get the initial set.

Spark ALS refers to this as cold start strategy and 'drop' makes better sense than dropping the default 'NaN' records after the fact.